### PR TITLE
fixes GH-87 : Add query API for child-src and frame-src

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/data/Policy.java
+++ b/src/main/java/com/shapesecurity/salvation/data/Policy.java
@@ -510,4 +510,20 @@ public class Policy implements Show {
     public boolean allowsStyleWithNonce(@Nonnull Base64Value nonce) {
         return this.allowsStyleWithNonce(nonce.value);
     }
+
+    public boolean allowsChildFromSource(@Nonnull URI source) {
+        ChildSrcDirective childSrcDirective = this.getDirectiveByType(ChildSrcDirective.class);
+        if (childSrcDirective == null) {
+            return this.defaultsAllowSource(source);
+        }
+        return childSrcDirective.matchesSource(this.origin, source);
+    }
+
+    public boolean allowsFrameFromSource(@Nonnull URI source) {
+        FrameSrcDirective frameSrcDirective = this.getDirectiveByType(FrameSrcDirective.class);
+        if (frameSrcDirective == null) {
+            return this.allowsChildFromSource(source);
+        }
+        return frameSrcDirective.matchesSource(this.origin, source);
+    }
 }


### PR DESCRIPTION
Although I think spec should be be clear on what to do if both child-src and frame-src exist. FF doesn't implement child-src yet, so technically it is not CSP 2.0 compliant, as caniuse says.