### PR TITLE
Add support for some more directives

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/Constants.java
+++ b/src/main/java/com/shapesecurity/salvation/Constants.java
@@ -4,6 +4,10 @@ import java.util.regex.Pattern;
 
 @SuppressWarnings("MalformedRegex") public class Constants {
     public static final String schemePart = "[a-zA-Z][a-zA-Z0-9+\\-.]*";
+    public static final Pattern referrerTokenPattern = Pattern.compile(
+            "^(?:no-referrer|no-referrer-when-downgrade|origin"
+                    + "|origin-when-cross-origin|unsafe-url)$",
+            Pattern.CASE_INSENSITIVE);
     public static final Pattern sandboxTokenPattern =
         Pattern.compile("^[!#$%&'*+\\-.^_`|~0-9a-zA-Z]+$");
     public static final Pattern mediaTypePattern =

--- a/src/main/java/com/shapesecurity/salvation/directiveValues/ReferrerValue.java
+++ b/src/main/java/com/shapesecurity/salvation/directiveValues/ReferrerValue.java
@@ -1,0 +1,26 @@
+package com.shapesecurity.salvation.directiveValues;
+
+import com.shapesecurity.salvation.directives.DirectiveValue;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class ReferrerValue implements DirectiveValue {
+    @Nonnull private final String value;
+
+    public ReferrerValue(@Nonnull String value) {
+        this.value = value;
+    }
+
+    @Nonnull @Override public String show() {
+        return this.value;
+    }
+
+    @Override public int hashCode() {
+        return this.value.hashCode();
+    }
+
+    @Override public boolean equals(@Nullable Object other) {
+        return other instanceof ReferrerValue && ((ReferrerValue) other).value.equals(this.value);
+    }
+}

--- a/src/main/java/com/shapesecurity/salvation/directives/BlockAllMixedContentDirective.java
+++ b/src/main/java/com/shapesecurity/salvation/directives/BlockAllMixedContentDirective.java
@@ -1,0 +1,17 @@
+package com.shapesecurity.salvation.directives;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Set;
+
+public class BlockAllMixedContentDirective extends Directive<DirectiveValue> {
+    @Nonnull private static final String NAME = "block-all-mixed-content";
+
+    public BlockAllMixedContentDirective() {
+        super(BlockAllMixedContentDirective.NAME, Collections.EMPTY_SET);
+    }
+
+    @Nonnull @Override public Directive<DirectiveValue> construct(Set<DirectiveValue> newValues) {
+        return new BlockAllMixedContentDirective();
+    }
+}

--- a/src/main/java/com/shapesecurity/salvation/directives/ManifestSrcDirective.java
+++ b/src/main/java/com/shapesecurity/salvation/directives/ManifestSrcDirective.java
@@ -1,0 +1,19 @@
+package com.shapesecurity.salvation.directives;
+
+import com.shapesecurity.salvation.directiveValues.SourceExpression;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+public class ManifestSrcDirective extends SourceListDirective {
+    @Nonnull private static final String name = "default-src";
+
+    public ManifestSrcDirective(@Nonnull Set<SourceExpression> sourceExpressions) {
+        super(ManifestSrcDirective.name, sourceExpressions);
+    }
+
+    @Nonnull @Override
+    public Directive<SourceExpression> construct(Set<SourceExpression> newValues) {
+        return new ManifestSrcDirective(newValues);
+    }
+}

--- a/src/main/java/com/shapesecurity/salvation/directives/ReferrerDirective.java
+++ b/src/main/java/com/shapesecurity/salvation/directives/ReferrerDirective.java
@@ -1,0 +1,18 @@
+package com.shapesecurity.salvation.directives;
+
+import com.shapesecurity.salvation.directiveValues.ReferrerValue;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+public class ReferrerDirective extends Directive<ReferrerValue> {
+    @Nonnull private static final String NAME = "referrer";
+
+    public ReferrerDirective(@Nonnull Set<ReferrerValue> values) {
+        super(ReferrerDirective.NAME, values);
+    }
+
+    @Nonnull @Override public Directive<ReferrerValue> construct(Set<ReferrerValue> newValues) {
+        return new ReferrerDirective(newValues);
+    }
+}

--- a/src/main/java/com/shapesecurity/salvation/directives/UpgradeInsecureRequestsDirective.java
+++ b/src/main/java/com/shapesecurity/salvation/directives/UpgradeInsecureRequestsDirective.java
@@ -1,0 +1,17 @@
+package com.shapesecurity.salvation.directives;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Set;
+
+public class UpgradeInsecureRequestsDirective extends Directive<DirectiveValue> {
+    @Nonnull private static final String NAME = "upgrade-insecure-requests";
+
+    public UpgradeInsecureRequestsDirective() {
+        super(UpgradeInsecureRequestsDirective.NAME, Collections.EMPTY_SET);
+    }
+
+    @Nonnull @Override public Directive<DirectiveValue> construct(Set<DirectiveValue> newValues) {
+        return new UpgradeInsecureRequestsDirective();
+    }
+}

--- a/src/main/java/com/shapesecurity/salvation/tokens/DirectiveNameToken.java
+++ b/src/main/java/com/shapesecurity/salvation/tokens/DirectiveNameToken.java
@@ -22,6 +22,7 @@ public class DirectiveNameToken extends Token {
 
     public enum DirectiveNameSubtype {
         BaseUri,
+        BlockAllMixedContent, // W3C Candidate Recommendation at http://www.w3.org/TR/mixed-content/#strict-opt-in as of 2015-09-22
         ChildSrc,
         ConnectSrc,
         DefaultSrc,
@@ -30,17 +31,16 @@ public class DirectiveNameToken extends Token {
         FrameAncestors,
         FrameSrc,
         ImgSrc,
+        ManifestSrc, // CSP3; in draft at http://w3c.github.io/webappsec-csp/#directive-manifest-src as of 2014-10-26
         MediaSrc,
         ObjectSrc,
         PluginTypes,
+        Referrer, // in draft at http://www.w3.org/TR/2014/WD-referrer-policy-20140807/#referrer-policy-delivery as of 2015-08-27
         ReportUri,
         Sandbox,
         ScriptSrc,
         StyleSrc,
-
-        Referrer, // in draft at http://www.w3.org/TR/2014/WD-referrer-policy-20140807/#referrer-policy-delivery as of 2015-08-27
-        UpgradeInsecureRequests, // in draft at http://www.w3.org/TR/2015/WD-upgrade-insecure-requests-20150424/#delivery as of 2015-08-27
-        BlockAllMixedContent, // W3C Candidate Recommendation at http://www.w3.org/TR/mixed-content/#strict-opt-in as of 2015-09-22
+        UpgradeInsecureRequests, // W3C Candidate Recommendation at https://www.w3.org/TR/upgrade-insecure-requests/#delivery as of 2015-10-08
 
         Allow, // never included in an official CSP specification
         Options; // never included in an official CSP specification
@@ -50,6 +50,8 @@ public class DirectiveNameToken extends Token {
             switch (directiveName.toLowerCase()) {
                 case "base-uri":
                     return BaseUri;
+                case "block-all-mixed-content":
+                    return BlockAllMixedContent;
                 case "child-src":
                     return ChildSrc;
                 case "connect-src":
@@ -62,16 +64,18 @@ public class DirectiveNameToken extends Token {
                     return FormAction;
                 case "frame-ancestors":
                     return FrameAncestors;
-                case "frame-src":
-                    return FrameSrc;
                 case "img-src":
                     return ImgSrc;
+                case "manifest-src":
+                    return ManifestSrc;
                 case "media-src":
                     return MediaSrc;
                 case "object-src":
                     return ObjectSrc;
                 case "plugin-types":
                     return PluginTypes;
+                case "referrer":
+                    return Referrer;
                 case "report-uri":
                     return ReportUri;
                 case "sandbox":
@@ -80,18 +84,16 @@ public class DirectiveNameToken extends Token {
                     return ScriptSrc;
                 case "style-src":
                     return StyleSrc;
-
-                // deprecated or proposed directives
-                case "allow":
-                    return Allow;
-                case "options":
-                    return Options;
-                case "referrer":
-                    return Referrer;
                 case "upgrade-insecure-requests":
                     return UpgradeInsecureRequests;
-                case "block-all-mixed-content":
-                    return BlockAllMixedContent;
+
+                // deprecated directives
+                case "allow":
+                    return Allow;
+                case "frame-src":
+                    return FrameSrc;
+                case "options":
+                    return Options;
             }
             return null;
         }


### PR DESCRIPTION
Support parsing/syntax-checking for the `block-all-mixed-content`, `manifest-src`, `referrer`, and `upgrade-insecure-requests` directives.

* `block-all-mixed-content`–W3C Candidate Recommendation, Chrome has shipped
* `manifest-src`–CSP3, Chrome and Firefox have shipped
*  `referrer`–W3C WD, Chrome and Firefox have shipped
* `upgrade-insecure-requests`–W3C Candidate Recommendation, Chrome and Firefox have shipped

If you want to land this but want to hold off on it til the GH-93 branch is merged, I’m happy to wait and rebase it once that’s landed. (There are some merge conflicts between this patch and the GH-93 changes, but I think it’ll be pretty straightforward for me to resolve them on this branch once they’re completed.)