### PR TITLE
Warn about "sandbox" values that aren't in HTML

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/Constants.java
+++ b/src/main/java/com/shapesecurity/salvation/Constants.java
@@ -6,6 +6,10 @@ import java.util.regex.Pattern;
     public static final String schemePart = "[a-zA-Z][a-zA-Z0-9+\\-.]*";
     public static final Pattern sandboxTokenPattern =
         Pattern.compile("^[!#$%&'*+\\-.^_`|~0-9a-zA-Z]+$");
+    public static final Pattern sandboxEnumeratedTokenPattern =
+        Pattern.compile("^(?:allow-forms|allow-modals|allow-pointer-lock"
+            + "|allow-popups|allow-popups-to-escape-sandbox|allow-same-origin"
+            + "|allow-scripts|allow-top-navigation)$");
     public static final Pattern mediaTypePattern =
         Pattern.compile("^(?<type>[^/]+)/(?<subtype>[^/]+)$");
     // port-part constants

--- a/src/main/java/com/shapesecurity/salvation/Parser.java
+++ b/src/main/java/com/shapesecurity/salvation/Parser.java
@@ -392,9 +392,17 @@ public class Parser {
 
     @Nonnull private SandboxValue parseSandboxToken() throws ParseException {
         Token token = this.advance();
-        Matcher matcher = Constants.sandboxTokenPattern.matcher(token.value);
+        Matcher matcher = Constants.sandboxEnumeratedTokenPattern.matcher(token.value);
         if (matcher.find()) {
             return new SandboxValue(token.value);
+        } else {
+            this.warn("sandbox should contain only allow-forms, allow-modals, "
+                + "allow-pointer-lock, allow-popups, allow-popups-to-escape-sandbox, "
+                + "allow-same-origin, allow-scripts, or allow-top-navigation");
+            matcher = Constants.sandboxTokenPattern.matcher(token.value);
+            if (matcher.find()) {
+                return new SandboxValue(token.value);
+            }
         }
         throw this.createError("expecting sandbox-token but found " + token.value);
     }


### PR DESCRIPTION
See also https://github.com/w3c/webappsec-csp/pull/55, which proposes that the valid value of the `sandbox` directive be normatively restricted by the spec to only the set of enumerated values that are actually defined in the HTML spec and recognized by browsers:

  https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-sandbox

But short of that spec change landing, for now it would seem to make sense to at least already be warning users if they supply misspelled or unrecognized values for the `sandbox` directive.

Note that this change doesn’t break any existing tests but if y’all actually do want this code/behavior change, then I will add the corresponding tests to this PR.