### PR TITLE
added helpers to get log messages as a stream

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/data/Notice.java
+++ b/src/main/java/com/shapesecurity/salvation/data/Notice.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Notice implements Show {
 
@@ -39,6 +40,18 @@ public class Notice implements Show {
             return new ArrayList<>();
         }
         return notices.stream().filter(Notice::isInfo).collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    @Nonnull public static Stream<Notice> getAllErrorsAsStream(@Nonnull Stream<Notice> notices) {
+        return notices.filter(Notice::isError);
+    }
+
+    @Nonnull public static Stream<Notice> getAllWarningsAsStream(@Nonnull Stream<Notice> notices) {
+        return notices.filter(Notice::isWarning);
+    }
+
+    @Nonnull public static Stream<Notice> getAllInfosAsStream(@Nonnull Stream<Notice> notices) {
+        return notices.filter(Notice::isInfo);
     }
 
     @Override public String toString() {

--- a/src/test/java/com/shapesecurity/salvation/LocationTest.java
+++ b/src/test/java/com/shapesecurity/salvation/LocationTest.java
@@ -6,6 +6,9 @@ import com.shapesecurity.salvation.tokens.Token;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -346,5 +349,19 @@ public class LocationTest extends CSPTest {
         assertEquals(0, errors.size());
         assertEquals(0, warnings.size());
         assertEquals(0, infos.size());
+
+        notices.clear();
+        ParserWithLocation.parse("script-src 'unsafe-redirect' aaa", URI.parse("https://origin"), notices);
+        Stream<Notice> s = Notice.getAllWarningsAsStream(notices.stream());
+        assertEquals(1, s.count());
+
+        notices.clear();
+        ParserWithLocation.parse("script-src 'unsafe-redirect' aaa; frame-src ' none'; style-src self; сдсд ", URI.parse("https://origin"), notices);
+        s = Notice.getAllWarningsAsStream(notices.stream());
+        assertEquals(3, s.count());
+        s = Notice.getAllErrorsAsStream(notices.stream());
+        assertEquals(3, s.count());
+        s = Notice.getAllInfosAsStream(notices.stream());
+        assertEquals(0, s.count());
     }
 }


### PR DESCRIPTION
@michaelficarra , I just added `getErrorAsStream`-like  helpers, and that should be enough. Converting everything to stream will make things over-complicated if even possible. 