### PR TITLE
Add missing word in report-to error message

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/Parser.java
+++ b/src/main/java/com/shapesecurity/salvation/Parser.java
@@ -547,7 +547,7 @@ public class Parser {
             }
             this.error(token, "Expecting RFC 7230 token but found \"" + token.value + "\".");
         } else {
-            this.error(directiveNameToken, "The report-to must contain exactly one RFC 7230 token.");
+            this.error(directiveNameToken, "The report-to directive must contain exactly one RFC 7230 token.");
         }
         throw INVALID_REPORT_TO_TOKEN;
     }

--- a/src/test/java/com/shapesecurity/salvation/ParserTest.java
+++ b/src/test/java/com/shapesecurity/salvation/ParserTest.java
@@ -347,12 +347,12 @@ public class ParserTest extends CSPTest {
 
         parseWithNotices("report-to ", notices);
         assertEquals(1, notices.size());
-        assertEquals("The report-to must contain exactly one RFC 7230 token.", notices.get(0).message);
+        assertEquals("The report-to directive must contain exactly one RFC 7230 token.", notices.get(0).message);
 
         notices.clear();
         parseWithNotices("report-to д", notices);
         assertEquals(2, notices.size());
-        assertEquals("The report-to must contain exactly one RFC 7230 token.", notices.get(0).message);
+        assertEquals("The report-to directive must contain exactly one RFC 7230 token.", notices.get(0).message);
         assertEquals("Expecting directive-value but found U+0434 (д). Non-ASCII and non-printable characters must be percent-encoded.", notices.get(1).message);
 
         notices.clear();


### PR DESCRIPTION
Add the word `directive` that was inadvertently omitted from the error message.