### PR TITLE
fixes #112: warn on duplicate directives

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/Parser.java
+++ b/src/main/java/com/shapesecurity/salvation/Parser.java
@@ -145,7 +145,13 @@ public class Parser {
             if (this.eat(DirectiveSeparatorToken.class))
                 continue;
             try {
-                policy.addDirective(this.parseDirective());
+                Directive<? extends DirectiveValue> directive = this.parseDirective();
+                // only add a directive if it doesn't exist; used for handling duplicate directives in CSP headers
+                if (policy.getDirectiveByType(directive.getClass()) == null) {
+                    policy.addDirective(directive);
+                } else {
+                    this.warn(this.tokens[this.index - 2], "Policy contains more than one " + directive.name + " directive. All but the first instance will be ignored.");
+                }
             } catch (DirectiveParseException ignored) {
             }
         }

--- a/src/main/java/com/shapesecurity/salvation/directives/Directive.java
+++ b/src/main/java/com/shapesecurity/salvation/directives/Directive.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class Directive<Value extends DirectiveValue> implements Show {
-    @Nonnull private final String name;
+    @Nonnull public final String name;
 
     @Nonnull private Set<Value> values;
 

--- a/src/test/java/com/shapesecurity/salvation/ParserTest.java
+++ b/src/test/java/com/shapesecurity/salvation/ParserTest.java
@@ -38,9 +38,18 @@ public class ParserTest extends CSPTest {
         ImgSrcDirective imgSrcDirective = p.getDirectiveByType(ImgSrcDirective.class);
         assertNotNull(imgSrcDirective);
         assertTrue(firstDirective instanceof ImgSrcDirective);
-        assertEquals("", imgSrcDirective, (ImgSrcDirective) firstDirective);
+        assertEquals("", imgSrcDirective, firstDirective);
         assertEquals("", "img-src", ImgSrcDirective.name);
         assertEquals("", "img-src a", imgSrcDirective.show());
+    }
+
+    @Test public void testDuplicatesWithLocation() {
+        Policy p;
+        ArrayList<Notice> notices = new ArrayList<>();
+        p = ParserWithLocation.parse("img-src a ;;; img-src b", "https://example.com", notices);
+        assertEquals(1, notices.size());
+        assertEquals("1:15: Policy contains more than one img-src directive. All but the first instance will be ignored.", notices.get(0).show());
+
     }
 
     @Test public void testDirectiveNameParsing() {


### PR DESCRIPTION
Apparently, we don't merge duplicate directives and we follow the spec. I am sure you would like to report it from different place but this approach is simple and works for me, so giving it a try.