### PR TITLE
fixes GH-130

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/data/Policy.java
+++ b/src/main/java/com/shapesecurity/salvation/data/Policy.java
@@ -144,6 +144,9 @@ public class Policy implements Show {
                         .filter(x -> !(x instanceof HostSource))
                         // * remove network-schemes in source list that contains *
                         .filter(x -> !(x instanceof SchemeSource) || !((SchemeSource) x).matchesNetworkScheme())
+                        // remove 'unsafe-inline' if source list contains hash or nonce
+                        .filter(x -> !((x == KeywordSource.UnsafeInline) &&
+                            (sourceListDirective.containsNonceSource() || sourceListDirective.containsHashSource())))
                         .collect(Collectors.toCollection(LinkedHashSet::new));
                     newSources.add(star.get());
                     this.directives.put(entry.getKey(), sourceListDirective.construct(newSources));

--- a/src/main/java/com/shapesecurity/salvation/directives/SourceListDirective.java
+++ b/src/main/java/com/shapesecurity/salvation/directives/SourceListDirective.java
@@ -1,10 +1,7 @@
 package com.shapesecurity.salvation.directives;
 
 import com.shapesecurity.salvation.data.*;
-import com.shapesecurity.salvation.directiveValues.HashSource;
-import com.shapesecurity.salvation.directiveValues.HostSource;
-import com.shapesecurity.salvation.directiveValues.KeywordSource;
-import com.shapesecurity.salvation.directiveValues.SourceExpression;
+import com.shapesecurity.salvation.directiveValues.*;
 import com.shapesecurity.salvation.interfaces.MatchesHash;
 import com.shapesecurity.salvation.interfaces.MatchesNonce;
 import com.shapesecurity.salvation.interfaces.MatchesSource;
@@ -37,6 +34,14 @@ public abstract class SourceListDirective extends Directive<SourceExpression>
     public boolean matchesNonce(@Nonnull String nonce) {
         return this.values().filter(x -> x instanceof MatchesNonce)
             .anyMatch(x -> ((MatchesNonce) x).matchesNonce(nonce));
+    }
+
+    public boolean containsHashSource() {
+        return this.values().anyMatch(x -> (x instanceof HashSource));
+    }
+
+    public boolean containsNonceSource() {
+        return this.values().anyMatch(x -> (x instanceof NonceSource));
     }
 
     @Nonnull public Directive<SourceExpression> resolveSelf(@Nonnull Origin origin) {

--- a/src/test/java/com/shapesecurity/salvation/LocationTest.java
+++ b/src/test/java/com/shapesecurity/salvation/LocationTest.java
@@ -410,6 +410,27 @@ public class LocationTest extends CSPTest {
             notices.get(1).toString());
     }
 
+    @Test public void testUnsafeInlineWarnings() {
+        ArrayList<Notice> notices = new ArrayList<>();
+        ParserWithLocation
+            .parse("script-src 'unsafe-inline' 'nonce-123'", URI.parse("https://origin"), notices);
+        assertEquals(2, notices.size());
+        Notice notice = notices.get(0);
+        assertEquals(
+            "1:28: Invalid base64-value (should be multiple of 4 bytes: 3). Consider using RFC4648 compliant base64 encoding implementation.",
+            notice.show());
+        assertEquals(
+            "Warning: Invalid base64-value (should be multiple of 4 bytes: 3). Consider using RFC4648 compliant base64 encoding implementation.",
+            notice.toString());
+        notice = notices.get(1);
+        assertEquals(
+            "1:28: The 'unsafe-inline' keyword-source has no effect in source lists that contain hash-source or nonce-source.",
+            notice.show());
+        assertEquals(
+            "Warning: The 'unsafe-inline' keyword-source has no effect in source lists that contain hash-source or nonce-source.",
+            notice.toString());
+    }
+
     @Test public void testNoticeHelpers() {
         ArrayList<Notice> notices = new ArrayList<>();
         ParserWithLocation.parse(

--- a/src/test/java/com/shapesecurity/salvation/PolicyQueryingTest.java
+++ b/src/test/java/com/shapesecurity/salvation/PolicyQueryingTest.java
@@ -136,6 +136,8 @@ public class PolicyQueryingTest extends CSPTest {
         assertTrue("style hash is allowed",
             p.allowsStyleWithHash(HashSource.HashAlgorithm.SHA512, new Base64Value("cGl6ZGE=")));
 
+        p = Parser.parse("default-src * 'unsafe-inline' 'nonce-123'", "https://abc.com");
+        assertFalse("inline script is not allowed", p.allowsUnsafeInlineScript());
     }
 
     @Test public void testAllowsPlugin() {
@@ -172,6 +174,14 @@ public class PolicyQueryingTest extends CSPTest {
                 "vSsar3708Jvp9Szi2NWZZ02Bqp1qRCFpbcTZPdBhnWgs5WtNZKnvCXdhztmeD2cmW192CF5bDufKRpayrW/isg==")));
         assertFalse("style hash is not allowed", p.allowsStyleWithHash(HashSource.HashAlgorithm.SHA512, new Base64Value(
             "vSsar3708Jvp9Szi2NWZZ02Bqp1qRCFpbcTZPdBhnWgs5WtNZKnvCXdhztmeD2cmW192CF5bDufKRpayrW/isg==")));
+
+        p = Parser.parse("default-src * 'unsafe-inline' 'sha512-vSsar3708Jvp9Szi2NWZZ02Bqp1qRCFpbcTZPdBhnWgs5WtNZKnvCXdhztmeD2cmW192CF5bDufKRpayrW/isg=='", "https://abc.com");
+        assertTrue("script hash is allowed", p.allowsScriptWithHash(HashSource.HashAlgorithm.SHA512, new Base64Value(
+            "vSsar3708Jvp9Szi2NWZZ02Bqp1qRCFpbcTZPdBhnWgs5WtNZKnvCXdhztmeD2cmW192CF5bDufKRpayrW/isg==")));
+        assertFalse("unknown script is not allowed", p.allowsScriptWithHash(HashSource.HashAlgorithm.SHA256, new Base64Value(
+            "7HY1KLziIDGNSsu67SifYO1B69r1EFEfvPg3McqyIcM=")));
+        assertFalse("unknown script is not allowed", p.allowsUnsafeInlineScript());
+        assertFalse("unknown style is not allowed", p.allowsUnsafeInlineStyle());
     }
 
     @Test public void testAllowsNonce() {
@@ -188,6 +198,12 @@ public class PolicyQueryingTest extends CSPTest {
         p = Parser.parse("default-src 'none'", "https://abc.com");
         assertFalse("script nonce is not allowed", p.allowsScriptWithNonce(new Base64Value("0gQAAA==")));
         assertFalse("style nonce is not allowed", p.allowsStyleWithNonce(new Base64Value("0gQAAA==")));
+
+        p = Parser.parse("default-src * 'unsafe-inline' 'nonce-0gQAAA=='", "https://abc.com");
+        assertTrue("script nonce is allowed", p.allowsScriptWithNonce(new Base64Value("0gQAAA==")));
+        assertFalse("script wrong nonce is not allowed", p.allowsScriptWithNonce(new Base64Value("1234")));
+        assertFalse("unsafe inline script is not allowed", p.allowsUnsafeInlineScript());
+        assertFalse("unsafe inline style is not allowed", p.allowsUnsafeInlineStyle());
     }
 
     @Test public void testAllowsConnect() {


### PR DESCRIPTION
- remove 'unsafe-inline' if hash or nonce is present in the same source list
- warn about disabled 'unsafe-inline' in a source list containing hash or source
- tests