### PR TITLE
Fixes GH-135

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/data/Base64Value.java
+++ b/src/main/java/com/shapesecurity/salvation/data/Base64Value.java
@@ -24,7 +24,7 @@ public class Base64Value implements Show {
 
         if (chars.length % 4 != 0) {
             throw new IllegalArgumentException("Invalid base64-value (should be multiple of 4 bytes: " + chars.length
-                + "). Consider using RFC4648 compliant base64 encoding implementation.");
+                + ").");
         }
 
         int i;
@@ -34,17 +34,17 @@ public class Base64Value implements Show {
             }
             if (!isBase64Char(chars[i])) {
                 throw new IllegalArgumentException(
-                    "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.");
+                    "Invalid base64-value (characters are not in the base64-value grammar).");
             }
         }
         if (i < chars.length - 2) {
             throw new IllegalArgumentException(
-                "Invalid base64-value (bad padding). Consider using RFC4648 compliant base64 encoding implementation.");
+                "Invalid base64-value (bad padding).");
         }
         for (; i < chars.length; i++) {
             if (chars[i] != '=') {
                 throw new IllegalArgumentException(
-                    "Invalid base64-value padding (illegal characters). Consider using RFC4648 compliant base64 encoding implementation.");
+                    "Invalid base64-value padding (illegal characters).");
             }
         }
 
@@ -57,7 +57,8 @@ public class Base64Value implements Show {
         return '0' <= ch && ch <= '9' ||
             'A' <= ch && ch <= 'Z' ||
             'a' <= ch && ch <= 'z' ||
-            ch == '+' || ch == '/';
+            ch == '+' || ch == '/' ||
+            ch == '-' || ch == '_';
     }
 
     public int size() {

--- a/src/main/java/com/shapesecurity/salvation/data/Policy.java
+++ b/src/main/java/com/shapesecurity/salvation/data/Policy.java
@@ -81,9 +81,7 @@ public class Policy implements Show {
         DefaultSrcDirective defaultSrcDirective = this.getDirectiveByType(DefaultSrcDirective.class);
         Set<SourceExpression> defaultSources;
         if (defaultSrcDirective == null) {
-            defaultSources = new LinkedHashSet<>();
-            defaultSources.add(HostSource.WILDCARD);
-            this.directives.put(DefaultSrcDirective.class, new DefaultSrcDirective(defaultSources));
+            return;
         } else {
             defaultSources = defaultSrcDirective.values().collect(Collectors.toCollection(LinkedHashSet::new));
         }
@@ -172,49 +170,40 @@ public class Policy implements Show {
         DefaultSrcDirective defaultSrcDirective = this.getDirectiveByType(DefaultSrcDirective.class);
 
         Set<SourceExpression> defaultSources;
-        if (defaultSrcDirective == null) {
-            defaultSources = new LinkedHashSet<>();
-            defaultSources.add(HostSource.WILDCARD);
-        } else {
+
+        if (defaultSrcDirective != null) {
             defaultSources = defaultSrcDirective.values().collect(Collectors.toCollection(LinkedHashSet::new));
-        }
 
-        // * remove source directives that are equivalent to default-src
-        this.eliminateRedundantSourceExpression(defaultSources, ScriptSrcDirective.class);
-        this.eliminateRedundantSourceExpression(defaultSources, StyleSrcDirective.class);
-        this.eliminateRedundantSourceExpression(defaultSources, ImgSrcDirective.class);
-        this.eliminateRedundantSourceExpression(defaultSources, ChildSrcDirective.class);
-        this.eliminateRedundantSourceExpression(defaultSources, ConnectSrcDirective.class);
-        this.eliminateRedundantSourceExpression(defaultSources, FontSrcDirective.class);
-        this.eliminateRedundantSourceExpression(defaultSources, MediaSrcDirective.class);
-        this.eliminateRedundantSourceExpression(defaultSources, ObjectSrcDirective.class);
-        this.eliminateRedundantSourceExpression(defaultSources, ManifestSrcDirective.class);
 
-        // * remove default-src nonces if the policy contains both script-src and style-src directives
-        if (this.directives.containsKey(ScriptSrcDirective.class) && this.directives
-            .containsKey(StyleSrcDirective.class)) {
-            defaultSources.removeIf(x -> x instanceof NonceSource);
-            defaultSrcDirective = new DefaultSrcDirective(defaultSources);
-            this.directives.put(DefaultSrcDirective.class, defaultSrcDirective);
-        }
+            // * remove source directives that are equivalent to default-src
+            this.eliminateRedundantSourceExpression(defaultSources, ScriptSrcDirective.class);
+            this.eliminateRedundantSourceExpression(defaultSources, StyleSrcDirective.class);
+            this.eliminateRedundantSourceExpression(defaultSources, ImgSrcDirective.class);
+            this.eliminateRedundantSourceExpression(defaultSources, ChildSrcDirective.class);
+            this.eliminateRedundantSourceExpression(defaultSources, ConnectSrcDirective.class);
+            this.eliminateRedundantSourceExpression(defaultSources, FontSrcDirective.class);
+            this.eliminateRedundantSourceExpression(defaultSources, MediaSrcDirective.class);
+            this.eliminateRedundantSourceExpression(defaultSources, ObjectSrcDirective.class);
+            this.eliminateRedundantSourceExpression(defaultSources, ManifestSrcDirective.class);
 
-        // * remove unnecessary default-src directives if all source directives exist
-        if (this.directives.containsKey(ScriptSrcDirective.class) &&
-            this.directives.containsKey(StyleSrcDirective.class) &&
-            this.directives.containsKey(ImgSrcDirective.class) &&
-            this.directives.containsKey(ChildSrcDirective.class) &&
-            this.directives.containsKey(ConnectSrcDirective.class) &&
-            this.directives.containsKey(FontSrcDirective.class) &&
-            this.directives.containsKey(MediaSrcDirective.class) &&
-            this.directives.containsKey(ObjectSrcDirective.class) &&
-            this.directives.containsKey(ManifestSrcDirective.class)) {
-            this.directives.remove(DefaultSrcDirective.class);
-        }
+            // * remove default-src nonces if the policy contains both script-src and style-src directives
+            if (this.directives.containsKey(ScriptSrcDirective.class) && this.directives
+                .containsKey(StyleSrcDirective.class)) {
+                defaultSources.removeIf(x -> x instanceof NonceSource);
+                defaultSrcDirective = new DefaultSrcDirective(defaultSources);
+                this.directives.put(DefaultSrcDirective.class, defaultSrcDirective);
+            }
 
-        // remove `default-src *`
-        if (defaultSources.size() == 1) {
-            SourceExpression first = defaultSources.iterator().next();
-            if (first instanceof HostSource && ((HostSource) first).isWildcard()) {
+            // * remove unnecessary default-src directives if all source directives exist
+            if (this.directives.containsKey(ScriptSrcDirective.class) &&
+                this.directives.containsKey(StyleSrcDirective.class) &&
+                this.directives.containsKey(ImgSrcDirective.class) &&
+                this.directives.containsKey(ChildSrcDirective.class) &&
+                this.directives.containsKey(ConnectSrcDirective.class) &&
+                this.directives.containsKey(FontSrcDirective.class) &&
+                this.directives.containsKey(MediaSrcDirective.class) &&
+                this.directives.containsKey(ObjectSrcDirective.class) &&
+                this.directives.containsKey(ManifestSrcDirective.class)) {
                 this.directives.remove(DefaultSrcDirective.class);
             }
         }
@@ -318,7 +307,7 @@ public class Policy implements Show {
             return true;
         DefaultSrcDirective defaultSrcDirective = this.getDirectiveByType(DefaultSrcDirective.class);
         if (defaultSrcDirective == null) {
-            return true;
+            return false;
         }
         return defaultSrcDirective.matchesHash(algorithm, hashValue);
     }
@@ -328,7 +317,7 @@ public class Policy implements Show {
             return true;
         DefaultSrcDirective defaultSrcDirective = this.getDirectiveByType(DefaultSrcDirective.class);
         if (defaultSrcDirective == null) {
-            return true;
+            return false;
         }
         return defaultSrcDirective.matchesNonce(nonce);
     }
@@ -342,7 +331,7 @@ public class Policy implements Show {
     private boolean defaultsAllowSource(@Nonnull URI source) {
         DefaultSrcDirective defaultSrcDirective = this.getDirectiveByType(DefaultSrcDirective.class);
         if (defaultSrcDirective == null) {
-            return true;
+            return false;
         }
         return defaultSrcDirective.matchesSource(this.origin, source);
     }

--- a/src/main/java/com/shapesecurity/salvation/directiveValues/NonceSource.java
+++ b/src/main/java/com/shapesecurity/salvation/directiveValues/NonceSource.java
@@ -22,11 +22,6 @@ public class NonceSource implements SourceExpression, MatchesNonce {
             // convert url-safe base64 to RFC4648 base64
             String safeValue = this.value.replace('-', '+').replace('_', '/');
             base64Value = new Base64Value(safeValue);
-            // warn if value is not RFC4648
-            if (this.value.contains("-") || this.value.contains("_")) {
-                errors.add(
-                    "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.");
-            }
         } catch (IllegalArgumentException e) {
             errors.add(e.getMessage());
             return errors;

--- a/src/test/java/com/shapesecurity/salvation/Base64ValueTest.java
+++ b/src/test/java/com/shapesecurity/salvation/Base64ValueTest.java
@@ -43,7 +43,7 @@ public class Base64ValueTest {
         Parser.parse("script-src 'self' https://example.com 'nonce-abc'", "https://origin", notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value (should be multiple of 4 bytes: 3). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value (should be multiple of 4 bytes: 3).",
             notices.get(0).show());
     }
 
@@ -54,14 +54,21 @@ public class Base64ValueTest {
             notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value (characters are not in the base64-value grammar).",
             notices.get(0).show());
 
         notices.clear();
         Parser.parse("script-src 'self' https://example.com 'nonce-1^=='", "https://origin", notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value (characters are not in the base64-value grammar).",
+            notices.get(0).show());
+
+        notices.clear();
+        Parser.parse("script-src 'self' https://example.com 'nonce-12_/-+=='", "https://origin", notices);
+        assertEquals(1, notices.size());
+        assertEquals(
+            "CSP specification recommends nonce-value to be at least 128 bits long (before encoding).",
             notices.get(0).show());
     }
 
@@ -71,14 +78,14 @@ public class Base64ValueTest {
         Parser.parse("script-src 'self' https://example.com 'nonce-12=+'", "https://origin", notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value padding (illegal characters). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value padding (illegal characters).",
             notices.get(0).show());
 
         notices.clear();
         Parser.parse("script-src 'self' https://example.com 'nonce-1==='", "https://origin", notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value (bad padding). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value (bad padding).",
             notices.get(0).show());
     }
 
@@ -86,12 +93,9 @@ public class Base64ValueTest {
         ArrayList<Notice> notices = new ArrayList<>();
 
         Parser.parse("script-src 'self' https://example.com 'nonce-31231asda_dsdsxc'", "https://origin", notices);
-        assertEquals(2, notices.size());
-        assertEquals(
-            "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.",
-            notices.get(0).show());
+        assertEquals(1, notices.size());
         assertEquals("CSP specification recommends nonce-value to be at least 128 bits long (before encoding).",
-            notices.get(1).show());
+            notices.get(0).show());
 
     }
 }

--- a/src/test/java/com/shapesecurity/salvation/LocationTest.java
+++ b/src/test/java/com/shapesecurity/salvation/LocationTest.java
@@ -417,10 +417,10 @@ public class LocationTest extends CSPTest {
         assertEquals(2, notices.size());
         Notice notice = notices.get(0);
         assertEquals(
-            "1:28: Invalid base64-value (should be multiple of 4 bytes: 3). Consider using RFC4648 compliant base64 encoding implementation.",
+            "1:28: Invalid base64-value (should be multiple of 4 bytes: 3).",
             notice.show());
         assertEquals(
-            "Warning: Invalid base64-value (should be multiple of 4 bytes: 3). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Warning: Invalid base64-value (should be multiple of 4 bytes: 3).",
             notice.toString());
         notice = notices.get(1);
         assertEquals(

--- a/src/test/java/com/shapesecurity/salvation/PolicyMergeTest.java
+++ b/src/test/java/com/shapesecurity/salvation/PolicyMergeTest.java
@@ -47,7 +47,7 @@ public class PolicyMergeTest extends CSPTest {
         p1 = parse("default-src *; script-src");
         p2 = parse("default-src; script-src b");
         p1.union(p2);
-        assertEquals("script-src b", p1.show());
+        assertEquals("default-src *; script-src b", p1.show());
 
         p1 = parse("default-src a");
         p2 = parse("default-src; script-src b");
@@ -82,6 +82,11 @@ public class PolicyMergeTest extends CSPTest {
 
     @Test public void testIntersect() {
         Policy p1, p2;
+
+        p1 = parse("default-src 'none';");
+        p2 = parse("default-src *;");
+        p1.intersect(p2);
+        assertEquals("default-src", p1.show());
 
         p1 = parse("default-src a; script-src b");
         p2 = parse("default-src c; img-src d");
@@ -126,7 +131,7 @@ public class PolicyMergeTest extends CSPTest {
         p1 = parse("default-src *; script-src *; style-src *:80");
         p2 = parse("default-src 'self'; script-src a");
         p1.intersect(p2);
-        assertEquals("style-src; default-src 'self'; script-src a", p1.show());
+        assertEquals("default-src 'self'; style-src; script-src a", p1.show());
 
         p1 = parse("default-src 'self'; script-src a");
         p2 = parse("default-src *; script-src *; style-src *:80");
@@ -313,7 +318,7 @@ public class PolicyMergeTest extends CSPTest {
         set.add(HostSource.WILDCARD);
         DefaultSrcDirective d3 = new DefaultSrcDirective(set);
         p.unionDirective(d3);
-        assertEquals("script-src a; report-uri http://example.com/z", p.show());
+        assertEquals("default-src *; script-src a; report-uri http://example.com/z", p.show());
 
         set.clear();
         p = Parser.parse("", "http://example.com");
@@ -324,7 +329,7 @@ public class PolicyMergeTest extends CSPTest {
 
         p.unionDirective(scriptSrcDirective);
         p.unionDirective(styleSrcDirective);
-        assertEquals("script-src 'nonce-Q-ecAIccSGatv6lJrCBVARPr' *; style-src 'nonce-Q-ecAIccSGatv6lJrCBVARPr' *",
+        assertEquals("script-src 'nonce-Q-ecAIccSGatv6lJrCBVARPr'; style-src 'nonce-Q-ecAIccSGatv6lJrCBVARPr'",
             p.show());
     }
 

--- a/src/test/java/com/shapesecurity/salvation/PolicyQueryingTest.java
+++ b/src/test/java/com/shapesecurity/salvation/PolicyQueryingTest.java
@@ -486,6 +486,19 @@ public class PolicyQueryingTest extends CSPTest {
         assertFalse(p.allowsScriptFromSource(new GUID("custom.scheme:")));
     }
 
+    @Test public void testEmptyPolicy() {
+        Policy p;
+
+        p = Parser.parse("", "http://example.com");
+        assertFalse(p.allowsScriptFromSource(URI.parse("http://example.com")));
+        assertFalse(p.allowsScriptFromSource(URI.parse("wss://example.com")));
+        assertFalse(p.allowsScriptWithNonce(new Base64Value("1234")));
+        assertFalse(p.allowsScriptWithHash(HashSource.HashAlgorithm.SHA512, new Base64Value(
+            "vSsar3708Jvp9Szi2NWZZ02Bqp1qRCFpbcTZPdBhnWgs5WtNZKnvCXdhztmeD2cmW192CF5bDufKRpayrW/isg==")));
+        assertFalse(p.allowsScriptFromSource(new GUID("custom.scheme:")));
+        assertFalse(p.allowsScriptFromSource(new GUID("data:")));
+    }
+
     @Test public void testHasSomeEffect() {
         Policy p = Parser.parse("", "http://example.com");
         assertFalse(p.hasSomeEffect());


### PR DESCRIPTION
- do not treat `default-src *` equivalent to an empty policy
- fixes assumption in query API that empty policy is most permissive