### PR TITLE
fixes #139

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/data/Base64Value.java
+++ b/src/main/java/com/shapesecurity/salvation/data/Base64Value.java
@@ -24,7 +24,7 @@ public class Base64Value implements Show {
 
         if (chars.length % 4 != 0) {
             throw new IllegalArgumentException("Invalid base64-value (should be multiple of 4 bytes: " + chars.length
-                + "). Consider using RFC4648 compliant base64 encoding implementation.");
+                + ").");
         }
 
         int i;
@@ -34,17 +34,17 @@ public class Base64Value implements Show {
             }
             if (!isBase64Char(chars[i])) {
                 throw new IllegalArgumentException(
-                    "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.");
+                    "Invalid base64-value (characters are not in the base64-value grammar).");
             }
         }
         if (i < chars.length - 2) {
             throw new IllegalArgumentException(
-                "Invalid base64-value (bad padding). Consider using RFC4648 compliant base64 encoding implementation.");
+                "Invalid base64-value (bad padding).");
         }
         for (; i < chars.length; i++) {
             if (chars[i] != '=') {
                 throw new IllegalArgumentException(
-                    "Invalid base64-value padding (illegal characters). Consider using RFC4648 compliant base64 encoding implementation.");
+                    "Invalid base64-value padding (illegal characters).");
             }
         }
 
@@ -57,7 +57,8 @@ public class Base64Value implements Show {
         return '0' <= ch && ch <= '9' ||
             'A' <= ch && ch <= 'Z' ||
             'a' <= ch && ch <= 'z' ||
-            ch == '+' || ch == '/';
+            ch == '+' || ch == '/' ||
+            ch == '-' || ch == '_';
     }
 
     public int size() {

--- a/src/main/java/com/shapesecurity/salvation/directiveValues/NonceSource.java
+++ b/src/main/java/com/shapesecurity/salvation/directiveValues/NonceSource.java
@@ -22,6 +22,12 @@ public class NonceSource implements SourceExpression, MatchesNonce {
             // convert url-safe base64 to RFC4648 base64
             String safeValue = this.value.replace('-', '+').replace('_', '/');
             base64Value = new Base64Value(safeValue);
+            // warn if value is not RFC4648
+            if ((this.value.contains("-") || this.value.contains("_")) &&
+                (this.value.contains("+") || this.value.contains("/"))) {
+                errors.add(
+                    "Invalid base64-value. Must use either RFC4648 \"base64\" characters (including + and /) or RFC4648 \"base64url\" characters (including - and _), but not both.");
+            }
         } catch (IllegalArgumentException e) {
             errors.add(e.getMessage());
             return errors;

--- a/src/main/java/com/shapesecurity/salvation/directiveValues/NonceSource.java
+++ b/src/main/java/com/shapesecurity/salvation/directiveValues/NonceSource.java
@@ -22,11 +22,6 @@ public class NonceSource implements SourceExpression, MatchesNonce {
             // convert url-safe base64 to RFC4648 base64
             String safeValue = this.value.replace('-', '+').replace('_', '/');
             base64Value = new Base64Value(safeValue);
-            // warn if value is not RFC4648
-            if (this.value.contains("-") || this.value.contains("_")) {
-                errors.add(
-                    "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.");
-            }
         } catch (IllegalArgumentException e) {
             errors.add(e.getMessage());
             return errors;

--- a/src/test/java/com/shapesecurity/salvation/Base64ValueTest.java
+++ b/src/test/java/com/shapesecurity/salvation/Base64ValueTest.java
@@ -43,7 +43,7 @@ public class Base64ValueTest {
         Parser.parse("script-src 'self' https://example.com 'nonce-abc'", "https://origin", notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value (should be multiple of 4 bytes: 3). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value (should be multiple of 4 bytes: 3).",
             notices.get(0).show());
     }
 
@@ -54,14 +54,21 @@ public class Base64ValueTest {
             notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value (characters are not in the base64-value grammar).",
             notices.get(0).show());
 
         notices.clear();
         Parser.parse("script-src 'self' https://example.com 'nonce-1^=='", "https://origin", notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value (characters are not in the base64-value grammar).",
+            notices.get(0).show());
+
+        notices.clear();
+        Parser.parse("script-src 'self' https://example.com 'nonce-12_/-+=='", "https://origin", notices);
+        assertEquals(1, notices.size());
+        assertEquals(
+            "CSP specification recommends nonce-value to be at least 128 bits long (before encoding).",
             notices.get(0).show());
     }
 
@@ -71,14 +78,14 @@ public class Base64ValueTest {
         Parser.parse("script-src 'self' https://example.com 'nonce-12=+'", "https://origin", notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value padding (illegal characters). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value padding (illegal characters).",
             notices.get(0).show());
 
         notices.clear();
         Parser.parse("script-src 'self' https://example.com 'nonce-1==='", "https://origin", notices);
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value (bad padding). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value (bad padding).",
             notices.get(0).show());
     }
 
@@ -86,12 +93,9 @@ public class Base64ValueTest {
         ArrayList<Notice> notices = new ArrayList<>();
 
         Parser.parse("script-src 'self' https://example.com 'nonce-31231asda_dsdsxc'", "https://origin", notices);
-        assertEquals(2, notices.size());
-        assertEquals(
-            "Invalid base64-value (characters are not in the base64-value grammar). Consider using RFC4648 compliant base64 encoding implementation.",
-            notices.get(0).show());
+        assertEquals(1, notices.size());
         assertEquals("CSP specification recommends nonce-value to be at least 128 bits long (before encoding).",
-            notices.get(1).show());
+            notices.get(0).show());
 
     }
 }

--- a/src/test/java/com/shapesecurity/salvation/LocationTest.java
+++ b/src/test/java/com/shapesecurity/salvation/LocationTest.java
@@ -417,10 +417,10 @@ public class LocationTest extends CSPTest {
         assertEquals(2, notices.size());
         Notice notice = notices.get(0);
         assertEquals(
-            "1:28: Invalid base64-value (should be multiple of 4 bytes: 3). Consider using RFC4648 compliant base64 encoding implementation.",
+            "1:28: Invalid base64-value (should be multiple of 4 bytes: 3).",
             notice.show());
         assertEquals(
-            "Warning: Invalid base64-value (should be multiple of 4 bytes: 3). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Warning: Invalid base64-value (should be multiple of 4 bytes: 3).",
             notice.toString());
         notice = notices.get(1);
         assertEquals(

--- a/src/test/java/com/shapesecurity/salvation/ParserTest.java
+++ b/src/test/java/com/shapesecurity/salvation/ParserTest.java
@@ -479,7 +479,7 @@ public class ParserTest extends CSPTest {
         assertEquals(0, p.getDirectives().size());
         assertEquals(1, notices.size());
         assertEquals(
-            "Invalid base64-value (should be multiple of 4 bytes: 43). Consider using RFC4648 compliant base64 encoding implementation.",
+            "Invalid base64-value (should be multiple of 4 bytes: 43).",
             notices.get(0).message);
 
         assertEquals("directive-name, directive-value",


### PR DESCRIPTION
- do not warn if base64 value matches either table 1 or table 2 grammar of RFC4648
- do not mention RFC4648 in warning messages