### PR TITLE
Added Missing Allows Checks to Policy

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/data/Policy.java
+++ b/src/main/java/com/shapesecurity/salvation/data/Policy.java
@@ -564,7 +564,71 @@ public class Policy implements Show {
         }
         return frameAncestorsDirective.matchesSource(this.origin, source);
     }
+    
+    public boolean allowsFontFromSource(@Nonnull URI source) {
+    	FontSrcDirective fontSrcDirective = this.getDirectiveByType(FontSrcDirective.class);
+        if (fontSrcDirective == null) {
+            return this.defaultsAllowSource(source);
+        }
+        return fontSrcDirective.matchesSource(this.origin, source);
+    }
 
+    public boolean allowsFontFromSource(@Nonnull GUID source) {
+        FontSrcDirective fontSrcDirective = this.getDirectiveByType(FontSrcDirective.class);
+        if (fontSrcDirective == null) {
+            return this.defaultsAllowSource(source);
+        }
+        return fontSrcDirective.matchesSource(this.origin, source);
+    }
+    
+    public boolean allowsObjectFromSource(@Nonnull URI source) {
+    	ObjectSrcDirective objectSrcDirective = this.getDirectiveByType(ObjectSrcDirective.class);
+        if (objectSrcDirective == null) {
+            return this.defaultsAllowSource(source);
+        }
+        return objectSrcDirective.matchesSource(this.origin, source);
+    }
+
+    public boolean allowsObjectFromSource(@Nonnull GUID source) {
+        ObjectSrcDirective objectSrcDirective = this.getDirectiveByType(ObjectSrcDirective.class);
+        if (objectSrcDirective == null) {
+            return this.defaultsAllowSource(source);
+        }
+        return objectSrcDirective.matchesSource(this.origin, source);
+    }
+
+    public boolean allowsMediaFromSource(@Nonnull URI source) {
+    	MediaSrcDirective mediaSrcDirective = this.getDirectiveByType(MediaSrcDirective.class);
+        if (mediaSrcDirective == null) {
+            return this.defaultsAllowSource(source);
+        }
+        return mediaSrcDirective.matchesSource(this.origin, source);
+    }
+
+    public boolean allowsMediaFromSource(@Nonnull GUID source) {
+        MediaSrcDirective mediaSrcDirective = this.getDirectiveByType(MediaSrcDirective.class);
+        if (mediaSrcDirective == null) {
+            return this.defaultsAllowSource(source);
+        }
+        return mediaSrcDirective.matchesSource(this.origin, source);
+    }
+    
+    public boolean allowsManifestFromSource(@Nonnull URI source) {
+    	ManifestSrcDirective manifestSrcDirective = this.getDirectiveByType(ManifestSrcDirective.class);
+        if (manifestSrcDirective == null) {
+            return this.defaultsAllowSource(source);
+        }
+        return manifestSrcDirective.matchesSource(this.origin, source);
+    }
+
+    public boolean allowsManifestFromSource(@Nonnull GUID source) {
+        ManifestSrcDirective manifestSrcDirective = this.getDirectiveByType(ManifestSrcDirective.class);
+        if (manifestSrcDirective == null) {
+            return this.defaultsAllowSource(source);
+        }
+        return manifestSrcDirective.matchesSource(this.origin, source);
+    }
+    
     public boolean hasSomeEffect() {
         for (Map.Entry<Class<?>, Directive<? extends DirectiveValue>> entry : this.directives.entrySet()) {
             Directive<? extends DirectiveValue> directive = entry.getValue();

--- a/src/test/java/com/shapesecurity/salvation/PolicyQueryingTest.java
+++ b/src/test/java/com/shapesecurity/salvation/PolicyQueryingTest.java
@@ -109,6 +109,31 @@ public class PolicyQueryingTest extends CSPTest {
         assertFalse("resource is not allowed", p.allowsFrameFromSource(URI.parse("http://www.def.am:555")));
         assertFalse("resource is not allowed", p.allowsChildFromSource(URI.parse("https://www.def.am:555")));
         assertTrue("resource is allowed", p.allowsChildFromSource(URI.parse("http://www.def.am:555")));
+        
+        p = Parser.parse("font-src https://font.com http://font.org", URI.parse("https://abc.com"));
+        assertTrue("resource is allowed", p.allowsFontFromSource(URI.parse("https://font.com")));
+        assertFalse("resource is not allowed", p.allowsFontFromSource(URI.parse("https://font.com:555")));
+        assertFalse("resource is not allowed", p.allowsFontFromSource(URI.parse("http://www.def.am:555")));
+        assertFalse("resource is not allowed", p.allowsFontFromSource(URI.parse("https://someco.net")));
+        
+        p = Parser.parse("object-src https://object.com http://object.org", URI.parse("https://abc.com"));
+        assertTrue("resource is allowed", p.allowsObjectFromSource(URI.parse("https://object.com")));
+        assertFalse("resource is not allowed", p.allowsObjectFromSource(URI.parse("https://object.com:555")));
+        assertFalse("resource is not allowed", p.allowsObjectFromSource(URI.parse("http://www.def.am:555")));
+        assertFalse("resource is not allowed", p.allowsObjectFromSource(URI.parse("https://someco.net")));
+        
+        p = Parser.parse("media-src https://media.com http://media.org", URI.parse("https://abc.com"));
+        assertTrue("resource is allowed", p.allowsMediaFromSource(URI.parse("https://media.com")));
+        assertFalse("resource is not allowed", p.allowsMediaFromSource(URI.parse("https://media.com:555")));
+        assertFalse("resource is not allowed", p.allowsMediaFromSource(URI.parse("http://www.def.am:555")));
+        assertFalse("resource is not allowed", p.allowsMediaFromSource(URI.parse("https://someco.net")));
+        
+        p = Parser.parse("manifest-src https://manifest.com http://manifest.org", URI.parse("https://abc.com"));
+        assertTrue("resource is allowed", p.allowsManifestFromSource(URI.parse("https://manifest.com")));
+        assertFalse("resource is not allowed", p.allowsManifestFromSource(URI.parse("https://manifest.com:555")));
+        assertFalse("resource is not allowed", p.allowsManifestFromSource(URI.parse("http://www.def.am:555")));
+        assertFalse("resource is not allowed", p.allowsManifestFromSource(URI.parse("https://someco.net")));
+        
     }
 
     @Test public void testAllowsUnsafeInline() {
@@ -484,6 +509,155 @@ public class PolicyQueryingTest extends CSPTest {
         assertFalse(p.allowsScriptFromSource(URI.parse("wss://example.com/PATH")));
         assertFalse(p.allowsScriptFromSource(new GUID("data:")));
         assertFalse(p.allowsScriptFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("font-src *", "http://example.com");
+        assertTrue(p.allowsFontFromSource(URI.parse("http://example.com")));
+        assertTrue(p.allowsFontFromSource(URI.parse("https://example.com")));
+        assertTrue(p.allowsFontFromSource(URI.parse("http://example.com:81")));
+        assertTrue(p.allowsFontFromSource(URI.parse("ftp://example.com")));
+        assertTrue(p.allowsFontFromSource(URI.parse("ftp://example.com:80")));
+        assertTrue(p.allowsFontFromSource(URI.parse("http://example.com/path")));
+        assertTrue(p.allowsFontFromSource(URI.parse("http://example.com/PATH")));
+        assertTrue(p.allowsFontFromSource(URI.parse("ws://example.com/PATH")));
+        assertTrue(p.allowsFontFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsFontFromSource(new GUID("data:")));
+        assertFalse(p.allowsFontFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("font-src http://*", "http://example.com");
+        assertTrue(p.allowsFontFromSource(URI.parse("http://example.com")));
+        assertFalse(p.allowsFontFromSource(URI.parse("https://example.com")));
+        assertFalse(p.allowsFontFromSource(URI.parse("http://example.com:81")));
+        assertFalse(p.allowsFontFromSource(URI.parse("ftp://example.com")));
+        assertFalse(p.allowsFontFromSource(URI.parse("ftp://example.com:80")));
+        assertTrue(p.allowsFontFromSource(URI.parse("http://example.com/path")));
+        assertTrue(p.allowsFontFromSource(URI.parse("http://example.com/PATH")));
+        assertFalse(p.allowsFontFromSource(URI.parse("ws://example.com/PATH")));
+        assertFalse(p.allowsFontFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsFontFromSource(new GUID("data:")));
+        assertFalse(p.allowsFontFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("font-src *.example.com", "http://example.com");
+        assertTrue(p.allowsFontFromSource(URI.parse("http://a.b.example.com/c/d")));
+        assertTrue(p.allowsFontFromSource(URI.parse("http://a.b.example.com")));
+        assertTrue(p.allowsFontFromSource(URI.parse("http://www.example.com")));
+        assertFalse(p.allowsFontFromSource(URI.parse("http://example.com")));
+        assertFalse(p.allowsFontFromSource(URI.parse("http://com")));
+        assertFalse(p.allowsFontFromSource(URI.parse("ws://example.com/PATH")));
+        assertFalse(p.allowsFontFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsFontFromSource(new GUID("data:")));
+        assertFalse(p.allowsFontFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("object-src *", "http://example.com");
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://example.com")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("https://example.com")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://example.com:81")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("ftp://example.com")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("ftp://example.com:80")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://example.com/path")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://example.com/PATH")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("ws://example.com/PATH")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsObjectFromSource(new GUID("data:")));
+        assertFalse(p.allowsObjectFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("object-src http://*", "http://example.com");
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://example.com")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("https://example.com")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("http://example.com:81")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("ftp://example.com")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("ftp://example.com:80")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://example.com/path")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://example.com/PATH")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("ws://example.com/PATH")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsObjectFromSource(new GUID("data:")));
+        assertFalse(p.allowsObjectFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("object-src *.example.com", "http://example.com");
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://a.b.example.com/c/d")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://a.b.example.com")));
+        assertTrue(p.allowsObjectFromSource(URI.parse("http://www.example.com")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("http://example.com")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("http://com")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("ws://example.com/PATH")));
+        assertFalse(p.allowsObjectFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsObjectFromSource(new GUID("data:")));
+        assertFalse(p.allowsObjectFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("media-src *", "http://example.com");
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://example.com")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("https://example.com")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://example.com:81")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("ftp://example.com")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("ftp://example.com:80")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://example.com/path")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://example.com/PATH")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("ws://example.com/PATH")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsMediaFromSource(new GUID("data:")));
+        assertFalse(p.allowsMediaFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("media-src http://*", "http://example.com");
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://example.com")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("https://example.com")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("http://example.com:81")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("ftp://example.com")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("ftp://example.com:80")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://example.com/path")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://example.com/PATH")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("ws://example.com/PATH")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsMediaFromSource(new GUID("data:")));
+        assertFalse(p.allowsMediaFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("media-src *.example.com", "http://example.com");
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://a.b.example.com/c/d")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://a.b.example.com")));
+        assertTrue(p.allowsMediaFromSource(URI.parse("http://www.example.com")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("http://example.com")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("http://com")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("ws://example.com/PATH")));
+        assertFalse(p.allowsMediaFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsMediaFromSource(new GUID("data:")));
+        assertFalse(p.allowsMediaFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("manifest-src *", "http://example.com");
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://example.com")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("https://example.com")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://example.com:81")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("ftp://example.com")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("ftp://example.com:80")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://example.com/path")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://example.com/PATH")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("ws://example.com/PATH")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsManifestFromSource(new GUID("data:")));
+        assertFalse(p.allowsManifestFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("manifest-src http://*", "http://example.com");
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://example.com")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("https://example.com")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("http://example.com:81")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("ftp://example.com")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("ftp://example.com:80")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://example.com/path")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://example.com/PATH")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("ws://example.com/PATH")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsManifestFromSource(new GUID("data:")));
+        assertFalse(p.allowsManifestFromSource(new GUID("custom.scheme:")));
+        
+        p = Parser.parse("manifest-src *.example.com", "http://example.com");
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://a.b.example.com/c/d")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://a.b.example.com")));
+        assertTrue(p.allowsManifestFromSource(URI.parse("http://www.example.com")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("http://example.com")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("http://com")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("ws://example.com/PATH")));
+        assertFalse(p.allowsManifestFromSource(URI.parse("wss://example.com/PATH")));
+        assertFalse(p.allowsManifestFromSource(new GUID("data:")));
+        assertFalse(p.allowsManifestFromSource(new GUID("custom.scheme:")));
+        
     }
 
     @Test public void testEmptyPolicy() {


### PR DESCRIPTION
Policy.java now includes allowXFromSource() checks, where X is one of the following:

- font (font-src)
- object (object-src)
- media (media-src)
- manifest (manifest-src)

This covers the remainder of the source directives that did not have checks matching the existing functionality. Include additions to PolicyQueryingTest.java.

Fixes shapesecurity/salvation#151