### PR TITLE
Fixes #128: Support `strict-dynamic` keyword-source

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/Constants.java
+++ b/src/main/java/com/shapesecurity/salvation/Constants.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
     public static final Pattern requireSriForEnumeratedTokenPattern = Pattern
             .compile("^(?:script|style)$", Pattern.CASE_INSENSITIVE);
     public static final Pattern mediaTypePattern = Pattern.compile("^(?<type>[^/]+)/(?<subtype>[^/]+)$");
-    public static final Pattern unquotedKeywordPattern = Pattern.compile("^(?:self|unsafe-inline|unsafe-eval|unsafe-redirect|none)$");
+    public static final Pattern unquotedKeywordPattern = Pattern.compile("^(?:self|unsafe-inline|unsafe-eval|unsafe-redirect|none|strict-dynamic)$");
     // port-part constants
     public static final int WILDCARD_PORT = -200;
     public static final int EMPTY_PORT = -1;

--- a/src/main/java/com/shapesecurity/salvation/directiveValues/KeywordSource.java
+++ b/src/main/java/com/shapesecurity/salvation/directiveValues/KeywordSource.java
@@ -13,6 +13,7 @@ public class KeywordSource implements SourceExpression, AncestorSource, MatchesS
     @Nonnull public static final KeywordSource UnsafeInline = new KeywordSource("unsafe-inline");
     @Nonnull public static final KeywordSource UnsafeEval = new KeywordSource("unsafe-eval");
     @Nonnull public static final KeywordSource UnsafeRedirect = new KeywordSource("unsafe-redirect");
+    @Nonnull public static final KeywordSource StrictDynamic = new KeywordSource("strict-dynamic");
     @Nonnull private final String value;
 
     private KeywordSource(@Nonnull String value) {

--- a/src/test/java/com/shapesecurity/salvation/PolicyMergeTest.java
+++ b/src/test/java/com/shapesecurity/salvation/PolicyMergeTest.java
@@ -78,6 +78,11 @@ public class PolicyMergeTest extends CSPTest {
         p2 = parse("default-src a");
         p1.union(p2);
         assertEquals("default-src b a; script-src a", p1.show());
+
+        p1 = parse("default-src 'strict-dynamic' 'nonce-1234' b; script-src a");
+        p2 = parse("default-src a");
+        p1.union(p2);
+        assertEquals("default-src 'strict-dynamic' 'nonce-1234' b a; script-src a", p1.show());
     }
 
     @Test public void testIntersect() {
@@ -137,6 +142,11 @@ public class PolicyMergeTest extends CSPTest {
         p2 = parse("default-src *; script-src *; style-src *:80");
         p1.intersect(p2);
         assertEquals("default-src 'self'; script-src a; style-src", p1.show());
+
+        p1 = parse("default-src 'self' 'strict-dynamic'; script-src a");
+        p2 = parse("default-src *; script-src *; style-src *:80");
+        p1.intersect(p2);
+        assertEquals("default-src 'self' 'strict-dynamic'; script-src a; style-src", p1.show());
 
         p1 = ParserWithLocation.parse("script-src a", URI.parse("https://origin"));
         p2 = parse("script-src b; report-uri /x");


### PR DESCRIPTION
This patch introduces basic support for
`strict-dynamic` keyword.