### PR TITLE
Ignore 'none' when union merge source-lists

### DIFF
--- a/src/main/java/com/shapesecurity/salvation/directives/Directive.java
+++ b/src/main/java/com/shapesecurity/salvation/directives/Directive.java
@@ -85,6 +85,8 @@ public abstract class Directive<Value extends DirectiveValue> implements Show {
         set.addAll(a);
         set.addAll(b);
 
+        set.remove(None.INSTANCE);
+
         Optional<T> star = set.stream().filter(x -> x instanceof HostSource && ((HostSource) x).isWildcard()).findAny();
         if (star.isPresent()) {
             set.removeIf(y -> y instanceof HostSource);

--- a/src/test/java/com/shapesecurity/salvation/PolicyMergeTest.java
+++ b/src/test/java/com/shapesecurity/salvation/PolicyMergeTest.java
@@ -529,4 +529,65 @@ public class PolicyMergeTest extends CSPTest {
         assertEquals("default-src a; frame-src a b; worker-src a b", p.show());
     }
 
+    @Test public void testUnionNone() {
+        Policy p = parse("frame-ancestors 'none'");
+        Policy q = parse("frame-ancestors 'self'");
+        p.union(q);
+        assertEquals("frame-ancestors 'self'", p.show());
+
+        p = parse("frame-ancestors 'none' 'none'");
+        q = parse("frame-ancestors 'self'");
+        p.union(q);
+        assertEquals("frame-ancestors 'self'", p.show());
+
+        p = parse("frame-ancestors 'self'");
+        q = parse("frame-ancestors 'none'");
+        p.union(q);
+        assertEquals("frame-ancestors 'self'", p.show());
+
+        p = parse("frame-ancestors a b c");
+        q = parse("frame-ancestors 'none'");
+        p.union(q);
+        assertEquals("frame-ancestors a b c", p.show());
+
+        p = parse("frame-ancestors 'none'");
+        q = parse("frame-ancestors 'none'");
+        p.union(q);
+        assertEquals("frame-ancestors", p.show());
+
+        p = parse("frame-ancestors *");
+        q = parse("frame-ancestors 'none'");
+        p.union(q);
+        assertEquals("frame-ancestors *", p.show());
+
+        p = parse("script-src 'none'");
+        q = parse("script-src 'self'");
+        p.union(q);
+        assertEquals("script-src 'self'", p.show());
+
+        p = parse("script-src 'none' 'none'");
+        q = parse("script-src 'self'");
+        p.union(q);
+        assertEquals("script-src 'self'", p.show());
+
+        p = parse("script-src 'self'");
+        q = parse("script-src 'none'");
+        p.union(q);
+        assertEquals("script-src 'self'", p.show());
+
+        p = parse("script-src a b c");
+        q = parse("script-src 'none'");
+        p.union(q);
+        assertEquals("script-src a b c", p.show());
+
+        p = parse("script-src 'none'");
+        q = parse("script-src 'none'");
+        p.union(q);
+        assertEquals("script-src", p.show());
+
+        p = parse("script-src *");
+        q = parse("script-src 'none'");
+        p.union(q);
+        assertEquals("script-src *", p.show());
+    }
 }


### PR DESCRIPTION
When union merging source-lists containing 'none',
make sure result is valid. E.g. `'none'` and `'self'` should
not produce `'none' 'self'`, but `'self'`.
Fixes #196