### PR TITLE
Switch to GHA for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: Java CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency: 
+  group:  ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: CLA Check
+        if: github.event_name == 'pull_request'
+        env:
+          TRAVIS_COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+        run: curl https://raw.githubusercontent.com/shapesecurity/CLA/HEAD/cla-travis.sh | bash
+      - name: Setup Java
+        if: success()
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - name: CI
+        if: success()
+        run: |
+          java -Xmx32m -version
+          javac -J-Xmx32m -version
+          mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          mvn test -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: java
-before_script:
-  - curl https://raw.githubusercontent.com/shapesecurity/CLA/HEAD/cla-travis.sh | bash
-jdk:
-  - openjdk8


### PR DESCRIPTION
Drop travis which is currently broken.

@michaelficarra @bakkot you can see test runs here: 
- push
    - https://github.com/kingthorin/saltest/actions/runs/1671719996
- PR
    - https://github.com/kingthorin/saltest/pull/1
        - https://github.com/kingthorin/saltest/actions/runs/1671838297

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>