### PR TITLE
Issue 248: Do not parse directives which are missing a space before the value

### DIFF
--- a/src/main/java/com/shapesecurity/salvation2/Policy.java
+++ b/src/main/java/com/shapesecurity/salvation2/Policy.java
@@ -130,6 +130,10 @@ public class Policy {
 
 			String remainingToken = strippedLeadingAndTrailingWhitespace.substring(directiveName.length());
 
+			if (remainingToken.length() > 0 && !containsLeadingWhitespace(remainingToken)) {
+				throw new IllegalArgumentException("directive value requires leading ascii whitespace");
+			}
+
 			List<String> directiveValues = Utils.splitOnAsciiWhitespace(remainingToken);
 
 			policy.add(directiveName, directiveValues, directiveErrorConsumer);
@@ -1081,6 +1085,11 @@ public class Policy {
 
 	private static String stripTrailingWhitespace(String string) {
 		return string.replaceAll("[" + Constants.WHITESPACE_CHARS + "]+$", "");
+	}
+
+	private static boolean containsLeadingWhitespace(String string) {
+		Matcher matcher = Pattern.compile("[" + Constants.WHITESPACE_CHARS + "]+").matcher(string);
+		return matcher.find() && matcher.start() == 0;
 	}
 
 	@Nonnull

--- a/src/test/java/com/shapesecurity/salvation2/ParserTest.java
+++ b/src/test/java/com/shapesecurity/salvation2/ParserTest.java
@@ -407,6 +407,13 @@ public class ParserTest extends TestBase {
 		);
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testIllegalLackOfWhitespace() {
+		roundTrips(
+				"default-src'self'"
+		);
+	}
+
 	@Test
 	public void testNone() {
 		// This asserts that it serializes to the same, uppercased, value


### PR DESCRIPTION
Addresses [Issue 248](https://github.com/shapesecurity/salvation/issues/248), wherein directives that have a value that does not contain a leading whitespace character should not be parsed.