### PR TITLE
bound checkstyle version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>[8.18,)</version>
+                        <version>[8.18,10.0)</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
Checkstyle version 10 dropped support for java 8, which we're still supporting for the moment (I guess).