### PR TITLE
chore: Address some SAST (SonarLint) findings & .gitignore for Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ build
 npm-debug.log
 key.pem
 cert.pem
+
+# Eclipse
+# -------
+*.classpath
+*.project
+*.settings

--- a/src/main/java/com/shapesecurity/salvation2/Constants.java
+++ b/src/main/java/com/shapesecurity/salvation2/Constants.java
@@ -47,5 +47,9 @@ public class Constants {
 	public static final Pattern IPv6addressWithOptionalBracket = Pattern.compile("^(?:\\[" + IPv6address + "\\]|" + IPv6address + ")$");
 
 	// https://infra.spec.whatwg.org/#ascii-whitespace
-	public static String WHITESPACE_CHARS = "\t\n\f\r ";
+	public static final String WHITESPACE_CHARS = "\t\n\f\r ";
+	
+	private Constants() {
+		// Utility class
+	}
 }

--- a/src/main/java/com/shapesecurity/salvation2/Directives/HostSourceDirective.java
+++ b/src/main/java/com/shapesecurity/salvation2/Directives/HostSourceDirective.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public abstract class HostSourceDirective extends Directive {
+	private static final String NONE_SRC = "'none'";
+	private static final String SELF_SRC = "'self'";
 	protected List<Scheme> schemes = new ArrayList<>();
 	protected List<Host> hosts = new ArrayList<>();
 	protected boolean star = false;
@@ -27,7 +29,7 @@ public abstract class HostSourceDirective extends Directive {
 	@Override
 	protected void addValue(String value) {
 		if (this.none != null) {
-			super.removeValueIgnoreCase("'none'"); // super so as to not immediately add it back
+			super.removeValueIgnoreCase(NONE_SRC); // super so as to not immediately add it back
 			this.none = null;
 		}
 		super.addValue(value);
@@ -37,8 +39,8 @@ public abstract class HostSourceDirective extends Directive {
 	protected void removeValueIgnoreCase(String value) {
 		super.removeValueIgnoreCase(value);
 		if (this.values.isEmpty()) {
-			this.values.add("'none'");
-			this.none = "'none'";
+			this.values.add(NONE_SRC);
+			this.none = NONE_SRC;
 		}
 	}
 
@@ -52,13 +54,13 @@ public abstract class HostSourceDirective extends Directive {
 		}
 		this.values = copy;
 		if (this.values.isEmpty()) {
-			this.values.add("'none'");
-			this.none = "'none'";
+			this.values.add(NONE_SRC);
+			this.none = NONE_SRC;
 		}
 	}
 
 	void _addHostOrSchemeDuringConstruction(String token, String lowcaseToken, String kind, int index, DirectiveErrorConsumer errors) {
-		if (lowcaseToken.equals("'none'")) {
+		if (lowcaseToken.equals(NONE_SRC)) {
 			if (this.none == null) {
 				this.none = token;
 			}
@@ -69,7 +71,7 @@ public abstract class HostSourceDirective extends Directive {
 			} else {
 				errors.add(Policy.Severity.Warning, "Duplicate " + kind + " *", index);
 			}
-		} else if (lowcaseToken.equals("'self'")) {
+		} else if (lowcaseToken.equals(SELF_SRC)) {
 			if (!this.self) {
 				this.self = true;
 			} else {
@@ -142,9 +144,9 @@ public abstract class HostSourceDirective extends Directive {
 			return;
 		}
 		if (self) {
-			this.addValue("'self'");
+			this.addValue(SELF_SRC);
 		} else {
-			this.removeValueIgnoreCase("'self'");
+			this.removeValueIgnoreCase(SELF_SRC);
 		}
 		this.self = self;
 	}

--- a/src/main/java/com/shapesecurity/salvation2/Directives/SandboxDirective.java
+++ b/src/main/java/com/shapesecurity/salvation2/Directives/SandboxDirective.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Locale;
 
 public class SandboxDirective extends Directive {
-
+	private static final String ALLOW_DOWNLOADS = "allow-downloads";
 	private boolean allowDownloads = false;
 	private boolean allowForms = false;
 	private boolean allowModals = false;
@@ -30,7 +30,7 @@ public class SandboxDirective extends Directive {
 			// HTML attribute keywords are ascii-case-insensitive: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes
 			String lowcaseToken = token.toLowerCase(Locale.ENGLISH);
 			switch (lowcaseToken) {
-				case "allow-downloads":
+				case ALLOW_DOWNLOADS:
 					if (!this.allowDownloads) {
 						this.allowDownloads = true;
 					} else {
@@ -142,9 +142,9 @@ public class SandboxDirective extends Directive {
 			return;
 		}
 		if (allowDownloads) {
-			this.addValue("allow-downloads");
+			this.addValue(ALLOW_DOWNLOADS);
 		} else {
-			this.removeValueIgnoreCase("allow-downloads");
+			this.removeValueIgnoreCase(ALLOW_DOWNLOADS);
 		}
 		this.allowDownloads = allowDownloads;
 	}

--- a/src/main/java/com/shapesecurity/salvation2/Directives/SourceExpressionDirective.java
+++ b/src/main/java/com/shapesecurity/salvation2/Directives/SourceExpressionDirective.java
@@ -11,6 +11,12 @@ import java.util.Locale;
 import java.util.Optional;
 
 public class SourceExpressionDirective extends HostSourceDirective {
+	private static final String REPORT_SAMPLE = "'report-sample'";
+	private static final String UNSAFE_INLINE = "'unsafe-inline'";
+	private static final String STRICT_DYNAMIC = "'strict-dynamic'";
+	private static final String UNSAFE_ALLOW_REDIRECTS = "'unsafe-allow-redirects'";
+	private static final String UNSAFE_EVAL = "'unsafe-eval'";
+	private static final String UNSAFE_HASHES = "'unsafe-hashes'";
 	private boolean unsafeInline = false;
 	private boolean unsafeEval = false;
 	private boolean strictDynamic = false;
@@ -31,42 +37,42 @@ public class SourceExpressionDirective extends HostSourceDirective {
 			// The CSP grammar uses ABNF grammars, whose strings are case-insensitive: https://tools.ietf.org/html/rfc5234
 			String lowcaseToken = token.toLowerCase(Locale.ENGLISH); // This needs to be ASCII-lowercase, so that `'strIct-dynamic''` still parses in Turkey
 			switch (lowcaseToken) {
-				case "'unsafe-inline'":
+				case UNSAFE_INLINE:
 					if (!this.unsafeInline) {
 						this.unsafeInline = true;
 					} else {
 						errors.add(Policy.Severity.Warning, "Duplicate source-expression 'unsafe-inline'", index);
 					}
 					break;
-				case "'unsafe-eval'":
+				case UNSAFE_EVAL:
 					if (!this.unsafeEval) {
 						this.unsafeEval = true;
 					} else {
 						errors.add(Policy.Severity.Warning, "Duplicate source-expression 'unsafe-eval'", index);
 					}
 					break;
-				case "'strict-dynamic'":
+				case STRICT_DYNAMIC:
 					if (!this.strictDynamic) {
 						this.strictDynamic = true;
 					} else {
 						errors.add(Policy.Severity.Warning, "Duplicate source-expression 'strict-dynamic'", index);
 					}
 					break;
-				case "'unsafe-hashes'":
+				case UNSAFE_HASHES:
 					if (!this.unsafeHashes) {
 						this.unsafeHashes = true;
 					} else {
 						errors.add(Policy.Severity.Warning, "Duplicate source-expression 'unsafe-hashes'", index);
 					}
 					break;
-				case "'report-sample'":
+				case REPORT_SAMPLE:
 					if (!this.reportSample) {
 						this.reportSample = true;
 					} else {
 						errors.add(Policy.Severity.Warning, "Duplicate source-expression 'report-sample'", index);
 					}
 					break;
-				case "'unsafe-allow-redirects'":
+				case UNSAFE_ALLOW_REDIRECTS:
 					if (!this.unsafeAllowRedirects) {
 						this.unsafeAllowRedirects = true;
 					} else {
@@ -160,9 +166,9 @@ public class SourceExpressionDirective extends HostSourceDirective {
 			return;
 		}
 		if (unsafeInline) {
-			this.addValue("'unsafe-inline'");
+			this.addValue(UNSAFE_INLINE);
 		} else {
-			this.removeValueIgnoreCase("'unsafe-inline'");
+			this.removeValueIgnoreCase(UNSAFE_INLINE);
 		}
 		this.unsafeInline = unsafeInline;
 	}
@@ -177,9 +183,9 @@ public class SourceExpressionDirective extends HostSourceDirective {
 			return;
 		}
 		if (unsafeEval) {
-			this.addValue("'unsafe-eval'");
+			this.addValue(UNSAFE_EVAL);
 		} else {
-			this.removeValueIgnoreCase("'unsafe-eval'");
+			this.removeValueIgnoreCase(UNSAFE_EVAL);
 		}
 		this.unsafeEval = unsafeEval;
 	}
@@ -194,9 +200,9 @@ public class SourceExpressionDirective extends HostSourceDirective {
 			return;
 		}
 		if (strictDynamic) {
-			this.addValue("'strict-dynamic'");
+			this.addValue(STRICT_DYNAMIC);
 		} else {
-			this.removeValueIgnoreCase("'strict-dynamic'");
+			this.removeValueIgnoreCase(STRICT_DYNAMIC);
 		}
 		this.strictDynamic = strictDynamic;
 	}
@@ -211,9 +217,9 @@ public class SourceExpressionDirective extends HostSourceDirective {
 			return;
 		}
 		if (unsafeHashes) {
-			this.addValue("'unsafe-hashes'");
+			this.addValue(UNSAFE_HASHES);
 		} else {
-			this.removeValueIgnoreCase("'unsafe-hashes'");
+			this.removeValueIgnoreCase(UNSAFE_HASHES);
 		}
 		this.unsafeHashes = unsafeHashes;
 	}
@@ -228,9 +234,9 @@ public class SourceExpressionDirective extends HostSourceDirective {
 			return;
 		}
 		if (reportSample) {
-			this.addValue("'report-sample'");
+			this.addValue(REPORT_SAMPLE);
 		} else {
-			this.removeValueIgnoreCase("'report-sample'");
+			this.removeValueIgnoreCase(REPORT_SAMPLE);
 		}
 		this.reportSample = reportSample;
 	}
@@ -245,9 +251,9 @@ public class SourceExpressionDirective extends HostSourceDirective {
 			return;
 		}
 		if (unsafeAllowRedirects) {
-			this.addValue("'unsafe-allow-redirects'");
+			this.addValue(UNSAFE_ALLOW_REDIRECTS);
 		} else {
-			this.removeValueIgnoreCase("'unsafe-allow-redirects'");
+			this.removeValueIgnoreCase(UNSAFE_ALLOW_REDIRECTS);
 		}
 		this.unsafeAllowRedirects = unsafeAllowRedirects;
 	}

--- a/src/main/java/com/shapesecurity/salvation2/Policy.java
+++ b/src/main/java/com/shapesecurity/salvation2/Policy.java
@@ -22,11 +22,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -66,7 +65,7 @@ public class Policy {
 	private boolean upgradeInsecureRequests = false;
 
 	@Nonnull
-	private final Map<FetchDirectiveKind, SourceExpressionDirective> fetchDirectives = new HashMap<>();
+	private final EnumMap<FetchDirectiveKind, SourceExpressionDirective> fetchDirectives = new EnumMap<>(FetchDirectiveKind.class);
 
 	private Policy() {
 		// pass
@@ -232,7 +231,7 @@ public class Policy {
 			case "report-to": {
 				// https://w3c.github.io/webappsec-csp/#directive-report-to
 				if (this.reportTo == null) {
-					if (values.size() == 0) {
+					if (values.isEmpty()) {
 						directiveErrorConsumer.add(Severity.Error, "The report-to directive requires a value", -1);
 					} else if (values.size() == 1) {
 						String token = values.get(0);
@@ -986,11 +985,7 @@ public class Policy {
 	private static boolean hostPartMatches(String A, String B) {
 		if (A.startsWith("*")) {
 			String remaining = A.substring(1);
-			if (B.toLowerCase(Locale.ENGLISH).endsWith(remaining.toLowerCase(Locale.ENGLISH))) {
-				return true;
-			} else {
-				return false;
-			}
+			return B.toLowerCase(Locale.ENGLISH).endsWith(remaining.toLowerCase(Locale.ENGLISH));
 		}
 
 		if (!A.equalsIgnoreCase(B)) {
@@ -1053,12 +1048,12 @@ public class Policy {
 			pathListA.remove(pathListA.size() - 1);
 		}
 
-		Iterator it1 = pathListA.iterator();
-		Iterator it2 = pathListB.iterator();
+		Iterator<String> it1 = pathListA.iterator();
+		Iterator<String> it2 = pathListB.iterator();
 
 		while (it1.hasNext()) {
-			String a = Utils.decodeString((String) it1.next());
-			String b = Utils.decodeString((String) it2.next());
+			String a = Utils.decodeString(it1.next());
+			String b = Utils.decodeString(it2.next());
 			if (!a.equals(b)) {
 				return false;
 			}

--- a/src/main/java/com/shapesecurity/salvation2/Utils.java
+++ b/src/main/java/com/shapesecurity/salvation2/Utils.java
@@ -44,4 +44,8 @@ public class Utils {
 			return s;
 		}
 	}
+	
+	private Utils() {
+		// Utility class
+	}
 }


### PR DESCRIPTION
* .gitignore > Ignore Eclipse IDE files.

- Make constants final.
- Add private constructors to utility/constant class to hide implicit public constructor.
- Add parameter types to generics (Iterator).
- Remove unnecessary casts.
- Use isEmpty to check collections (vs size() == 0).
- Replace nested if-then-else with a single return where possible.
- Use EnumMap where applicable.
- Replace multiple uses of literal strings with constants.

There are also a ton of naming things that SonarLint brings up (constants not using full caps, packages not using all lower, etc.). However, those changes would break binary compatibility so I didn't tackle them.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>