### PR TITLE
Update example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ policy.add("sandbox", Collections.emptyList(), Directive.DirectiveErrorConsumer.
 policy.sandbox().get().setAllowScripts(true);
 
 // or you can use the lower-level APIs to manipulate values directly 
-policy.sandbox().get().addValue("allow-something-new");
+policy.sandbox().get().setValue(SandboxDirective.Value.AllowPopupsToEscapeSandbox, false);
 
 // "sandbox allow-scripts allow-something-new"
 System.out.println(policy.toString());


### PR DESCRIPTION
Following example doesn't work, because `addValue` has `protected` modifier:
```java
policy.sandbox().get().addValue("allow-something-new");
```
Instead of removing it, it was replaced with usage of `SandboxDirective.Value` enum, that I've added in #258:
```java
policy.sandbox().get().setValue(SandboxDirective.Value.AllowPopupsToEscapeSandbox, false);
```