### PR TITLE
Address deprecation of plugin-types and prefetch-src

### DIFF
--- a/src/main/java/com/shapesecurity/salvation2/Policy.java
+++ b/src/main/java/com/shapesecurity/salvation2/Policy.java
@@ -57,6 +57,8 @@ public class Policy {
 
 	private PluginTypesDirective pluginTypes;
 
+	private FetchDirectiveKind prefetchSrc;
+
 	private RFC7230Token reportTo;
 
 	private ReportUriDirective reportUri;
@@ -220,7 +222,9 @@ public class Policy {
 				break;
 			}
 			case "plugin-types": {
-				// https://w3c.github.io/webappsec-csp/#directive-plugin-types
+				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types
+				directiveErrorConsumer.add(Severity.Warning,"The plugin-types directive has been deprecated", -1);
+
 				PluginTypesDirective thisDirective = new PluginTypesDirective(values, directiveErrorConsumer);
 				if (this.pluginTypes == null) {
 					this.pluginTypes = thisDirective;
@@ -297,6 +301,9 @@ public class Policy {
 				}
 				FetchDirectiveKind fetchDirectiveKind = FetchDirectiveKind.fromString(lowcaseDirectiveName);
 				if (fetchDirectiveKind != null) {
+					if (FetchDirectiveKind.PrefetchSrc == fetchDirectiveKind) {
+						directiveErrorConsumer.add(Severity.Warning,"The prefetch-src directive has been deprecated", -1);
+					}
 					SourceExpressionDirective thisDirective = new SourceExpressionDirective(values, directiveErrorConsumer);
 					if (this.fetchDirectives.containsKey(fetchDirectiveKind)) {
 						wasDupe = true;
@@ -447,6 +454,10 @@ public class Policy {
 
 	public Optional<PluginTypesDirective> pluginTypes() {
 		return Optional.ofNullable(this.pluginTypes);
+	}
+
+	public Optional<FetchDirectiveKind> prefetchSrc() {
+		return Optional.ofNullable(this.prefetchSrc);
 	}
 
 	public Optional<RFC7230Token> reportTo() {

--- a/src/test/java/com/shapesecurity/salvation2/HighLevelPolicyManipulationTest.java
+++ b/src/test/java/com/shapesecurity/salvation2/HighLevelPolicyManipulationTest.java
@@ -1,5 +1,6 @@
 package com.shapesecurity.salvation2;
 
+import com.shapesecurity.salvation2.Policy.PolicyErrorConsumer;
 import com.shapesecurity.salvation2.Directives.FrameAncestorsDirective;
 import com.shapesecurity.salvation2.Directives.PluginTypesDirective;
 import com.shapesecurity.salvation2.Directives.ReportUriDirective;
@@ -82,7 +83,7 @@ public class HighLevelPolicyManipulationTest extends TestBase {
 
 			for (SourceDirectiveKind kind : directives) {
 				String none = "'NoNe'";
-				Policy p = Policy.parseSerializedCSP(kind.repr + " " + none, throwIfPolicyError);
+				Policy p = Policy.parseSerializedCSP(kind.repr + " " + none, PolicyErrorConsumer.ignored);
 				SourceExpressionDirective d = kind.get.apply(p);
 
 
@@ -583,7 +584,7 @@ public class HighLevelPolicyManipulationTest extends TestBase {
 	@Test
 	public void testPluginTypesDirective() {
 		inTurkey(() -> {
-			Policy p = Policy.parseSerializedCSP("plugin-types", throwIfPolicyError);
+			Policy p = Policy.parseSerializedCSP("plugin-types", Policy.PolicyErrorConsumer.ignored);
 			PluginTypesDirective d = p.pluginTypes().get();
 
 			assertTrue(d.getMediaTypes().isEmpty());

--- a/src/test/java/com/shapesecurity/salvation2/LowLevelPolicyManipulationTest.java
+++ b/src/test/java/com/shapesecurity/salvation2/LowLevelPolicyManipulationTest.java
@@ -2,6 +2,8 @@ package com.shapesecurity.salvation2;
 
 import org.junit.Test;
 
+import com.shapesecurity.salvation2.Policy.PolicyErrorConsumer;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -174,7 +176,7 @@ public class LowLevelPolicyManipulationTest extends TestBase {
 		assertFalse(p.navigateTo().isPresent());
 		assertEquals("", p.toString());
 
-		p = Policy.parseSerializedCSP("plugin-types a/b", throwIfPolicyError);
+		p = Policy.parseSerializedCSP("plugin-types a/b", PolicyErrorConsumer.ignored);
 		assertTrue(p.pluginTypes().isPresent());
 		assertTrue(p.remove("plugin-types"));
 		assertFalse(p.remove("plugin-types"));


### PR DESCRIPTION
- Policy > Updated with appropriate deprecation notices and handling.
- Test classes > Updated to assert the new behavior and ignore errors where applicable.

Related to: https://github.com/zaproxy/zaproxy/issues/8077 and https://github.com/zaproxy/zap-extensions/pull/4950